### PR TITLE
change Plug.MIME to MIME to resolve deprecation warnings

### DIFF
--- a/lib/turbolinks/helpers.ex
+++ b/lib/turbolinks/helpers.ex
@@ -21,7 +21,7 @@ defmodule Turbolinks.Helpers do
   """
   def js(conn, data) do
     conn
-    |> Plug.Conn.put_resp_content_type(Plug.MIME.type("js"))
+    |> Plug.Conn.put_resp_content_type(MIME.type("js"))
     |> Plug.Conn.send_resp(conn.status || 200, data)
   end
 


### PR DESCRIPTION
Changed it because of the following warning:
```
Plug.MIME.type/1 is deprecated, please use MIME.type/1 instead
    (turbolinks) lib/turbolinks/helpers.ex:24: Turbolinks.Helpers.js/2
```