### PR TITLE
Add option to put custom status code on the conn

### DIFF
--- a/lib/turbolinks/helpers.ex
+++ b/lib/turbolinks/helpers.ex
@@ -9,7 +9,7 @@ defmodule Turbolinks.Helpers do
   def redirect(conn, opts) do
     if xhr?(conn) do
       conn
-      |> Plug.Conn.put_status(302)
+      |> Plug.Conn.put_status(opts[:xhr_status] || 302)
       |> js(turbolinks_resp(opts[:to] || opts[:external], conn.method))
     else
       Phoenix.Controller.redirect(conn, opts)

--- a/test/turbolinks_test.exs
+++ b/test/turbolinks_test.exs
@@ -1,8 +1,17 @@
 defmodule TurbolinksTest do
   use ExUnit.Case
+  use Plug.Test
+  use Turbolinks
   doctest Turbolinks
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  describe "redirect/2" do
+    test "returns the conn with status 308 if :xhr_status is 308" do
+      conn =
+        conn(:post, "/", "")
+        |> put_req_header("x-requested-with", "XMLHttpRequest")
+        |> redirect(to: "/url", xhr_status: 308)
+
+      assert conn.status == 308
+    end
   end
 end


### PR DESCRIPTION
**Problem:**
In IE11, the request body is empty when we use redirect via XHR, with status code 302. This way this code won't be executed:
```js
      Turbolinks.clearCache();
      Turbolinks.visit('#{to}');
```

Now we want to do a user agent check on IE11 in our code, and we would like to set the status code to something different than 302 (for example 308) so that the request body is working for IE11. 
This is not a very nice solution, but it's needed for us to make this work in IE11.

**Solution:**
Add an option to pass the status code you want to use for the redirect. 