### PR TITLE
Phoenix 1.4 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ head
 ++  meta name="csrf-token" content="#{get_csrf_token()}"
 ++  meta name="csrf-param" content="_csrf_token"
   ...
---  script src="#{static_path(@conn, "/js/app.js")}"
-++  script data-turbolinks-track="reload" src="#{static_path(@conn, "/js/app.js")}"
+--  script src="#{Routes.static_path(@conn, "/js/app.js")}"
+++  script data-turbolinks-track="reload" src="#{Routes.static_path(@conn, "/js/app.js")}"
   ...
 body
   ...


### PR DESCRIPTION
From Phoenix 1.4, Routes alias is used in replace of routes helper imports.